### PR TITLE
Part two of two

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ log/*
 tmp/*
 doc/*
 pkg/*
+*.swp

--- a/lib/joint.rb
+++ b/lib/joint.rb
@@ -44,7 +44,7 @@ module Joint
           else
             self["#{name}_id"]             = BSON::ObjectId.new if self["#{name}_id"].nil?
             self["#{name}_size"]           = File.size(file)
-            self["#{name}_type"]           = Wand.wave(file.path)
+            self["#{name}_type"]           = Wand.wave(file.path, :original_filename => Joint.file_name(file))
             self["#{name}_name"]           = Joint.file_name(file)
             assigned_attachments[:#{name}] = file
             nil_attachments.delete(:#{name})


### PR DESCRIPTION
This is the second part of my file upload fix for joint/wand content type fixes. Essentially just adding the :original_filename option...
Wand.wave(file.path, :original_filename => Joint.file_name(file))

All this is so that MIME::Types can see what the extension is supposed to be, given that the uploaded temporary file has none.

-Ray
