### PR TITLE
Prepare for MM 0.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
-source "http://rubygems.org"
+source :rubygems
+source Source::Git.new("uri" => "git://github.com/jnunemaker/mongomapper.git")
 
-gem 'i18n', '0.4.2'
-gem 'bson_ext', '~> 1.1', :require => false
+gem 'i18n',         '0.4.2'
+gem 'bson_ext',     '~> 1.2.4', :require => false
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,39 @@
+GIT
+  remote: git://github.com/jnunemaker/mongomapper.git
+  revision: ae943070db905856f1844dd19b292c1a0eb2f580
+  specs:
+    mongo_mapper (0.9.0)
+      activemodel (~> 3.0.0)
+      activesupport (~> 3.0.0)
+      plucky (~> 0.3.6)
+
 PATH
   remote: .
   specs:
-    joint (0.5.2)
+    joint (0.6.0)
       mime-types
-      mongo_mapper (~> 0.8.6)
+      mongo_mapper (~> 0.9.0)
       wand (~> 0.4)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.3)
-    bson (1.1.5)
-    bson_ext (1.1.5)
+    activemodel (3.0.5)
+      activesupport (= 3.0.5)
+      builder (~> 2.1.2)
+      i18n (~> 0.4)
+    activesupport (3.0.5)
+    bson (1.2.4)
+    bson_ext (1.2.4)
+    builder (2.1.2)
     i18n (0.4.2)
     jnunemaker-matchy (0.4.0)
-    jnunemaker-validatable (1.8.4)
-      activesupport (>= 2.3.4)
     mime-types (1.16)
     mocha (0.9.10)
       rake
-    mongo (1.1.5)
-      bson (>= 1.1.5)
-    mongo_mapper (0.8.6)
-      activesupport (>= 2.3.4)
-      jnunemaker-validatable (~> 1.8.4)
-      plucky (~> 0.3.6)
-    plucky (0.3.6)
+    mongo (1.2.4)
+      bson (>= 1.2.4)
+    plucky (0.3.7)
       mongo (~> 1.1)
     rake (0.8.7)
     safe_shell (1.0.0)
@@ -38,12 +46,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bson_ext (~> 1.1)
+  bson_ext (~> 1.2.4)
   i18n (= 0.4.2)
   jnunemaker-matchy
   joint!
   mime-types
   mocha
-  mongo_mapper (~> 0.8.6)
+  mongo_mapper (~> 0.9.0)
   shoulda
   wand (~> 0.4)

--- a/joint.gemspec
+++ b/joint.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'wand', '~> 0.4'
   s.add_dependency 'mime-types'
-  s.add_dependency 'mongo_mapper', '~> 0.8.6'
+  s.add_dependency 'mongo_mapper', '~> 0.9.0'
 
   s.add_development_dependency 'shoulda'
   s.add_development_dependency 'mocha'

--- a/lib/joint.rb
+++ b/lib/joint.rb
@@ -3,10 +3,12 @@ require 'mime/types'
 require 'wand'
 
 module Joint
-  def self.configure(model)
-    model.class_inheritable_accessor :attachment_names
-    model.attachment_names = Set.new
-    model.send(:include, model.attachment_accessor_module)
+  extend ActiveSupport::Concern
+
+  included do
+    class_inheritable_accessor :attachment_names
+    self.attachment_names = Set.new
+    include attachment_accessor_module
   end
 
   def self.name(file)

--- a/lib/joint/attachment_proxy.rb
+++ b/lib/joint/attachment_proxy.rb
@@ -23,6 +23,7 @@ module Joint
     def nil?
       !@instance.send("#{@name}?")
     end
+    alias_method :blank?, :nil?
 
     def grid_io
       @grid_io ||= @instance.grid.get(id)

--- a/lib/joint/version.rb
+++ b/lib/joint/version.rb
@@ -1,3 +1,3 @@
 module Joint
-  Version = '0.5.5'
+  Version = '0.6.0'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,6 @@
+require 'bundler/setup'
+Bundler.setup(:default, 'test', 'development')
+
 require 'tempfile'
 require 'pp'
 require 'shoulda'

--- a/test/test_joint.rb
+++ b/test/test_joint.rb
@@ -158,6 +158,11 @@ class JointTest < Test::Unit::TestCase
       subject.file.nil?.should be(false)
     end
 
+    should "respond with false when asked if the attachment is blank?" do
+      subject.image.blank?.should be(false)
+      subject.file.blank?.should be(false)
+    end
+
     should "clear assigned attachments so they don't get uploaded twice" do
       Mongo::Grid.any_instance.expects(:put).never
       subject.save
@@ -247,6 +252,11 @@ class JointTest < Test::Unit::TestCase
       subject.image.nil?.should be(true)
     end
 
+    should "respond with true when asked if the attachment is blank?" do
+      subject.image = nil
+      subject.image.blank?.should be(true)
+    end
+
     should "clear nil attachments after save and not attempt to delete again" do
       Mongo::Grid.any_instance.expects(:delete).once
       subject.image = nil
@@ -323,6 +333,8 @@ class JointTest < Test::Unit::TestCase
         include MongoMapper::Document
         plugin Joint
         attachment :file, :required => true
+
+        def self.name; "Foo"; end
       end
     end
 


### PR DESCRIPTION
joint 0.5.5 depends on MM ~0.8.6.  This bumps the joint version to 0.6.0 and makes updates for 0.9.0 compatibility.
