### PR TITLE
Switch from class_inheritable_accessor to class_attribute

### DIFF
--- a/lib/joint.rb
+++ b/lib/joint.rb
@@ -6,7 +6,7 @@ module Joint
   extend ActiveSupport::Concern
 
   included do
-    class_inheritable_accessor :attachment_names
+    class_attribute :attachment_names
     self.attachment_names = Set.new
     include attachment_accessor_module
   end

--- a/lib/joint/class_methods.rb
+++ b/lib/joint/class_methods.rb
@@ -8,7 +8,7 @@ module Joint
       options.symbolize_keys!
       name = name.to_sym
 
-      self.attachment_names << name
+      self.attachment_names = attachment_names.dup.add(name)
 
       after_save     :save_attachments
       after_save     :destroy_nil_attachments


### PR DESCRIPTION
class_inheritable_accessor is deprecated in Rails 3.1. class_attribute has slightly different semantics, but this change should be functionality neutral since it appears there's only one place where the attachment_names Set is modified.
