### PR TITLE
Leave reading the IO to Mongo::Grid

### DIFF
--- a/lib/joint/instance_methods.rb
+++ b/lib/joint/instance_methods.rb
@@ -19,7 +19,7 @@ module Joint
           next unless io.respond_to?(:read)
           io.rewind if io.respond_to?(:rewind)
           grid.delete(send(name).id)
-          grid.put(io.read, {
+          grid.put(io, {
             :_id          => send(name).id,
             :filename     => send(name).name,
             :content_type => send(name).type,

--- a/lib/joint/io.rb
+++ b/lib/joint/io.rb
@@ -1,3 +1,5 @@
+require 'stringio'
+
 module Joint
   class IO
     attr_accessor :name, :content, :type, :size
@@ -5,10 +7,17 @@ module Joint
     def initialize(attrs={})
       attrs.each { |key, value| send("#{key}=", value) }
       @type ||= 'plain/text'
-      @size ||= @content.size unless @content.nil?
+    end
+
+    def content=(value)
+      @io = StringIO.new(value || nil)
+      @size = value ? value.size : 0
+    end
+
+    def read(*args)
+      @io.read(*args)
     end
 
     alias path name
-    alias read content
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -70,7 +70,9 @@ module JointTestHelpers
   end
 
   def open_file(name)
-    File.open(File.join(File.dirname(__FILE__), 'fixtures', name), 'r')
+    f = File.open(File.join(File.dirname(__FILE__), 'fixtures', name), 'r')
+    f.binmode
+    f
   end
 
   def grid


### PR DESCRIPTION
Closes #10.

> Mongo::Grid reads IOs chunkwise to avoid unnecessary memory usage. Is there a particular reason why save_attachments rewinds and reads the io into memory?
> 
> See: https://github.com/jnunemaker/joint/blob/master/lib/joint/instance_methods.rb#L22

Had to `binmode` fixtures first to get the tests pass on my machine.
