### PR TITLE
Added rewind() method on Joint:IO.

### DIFF
--- a/lib/joint/io.rb
+++ b/lib/joint/io.rb
@@ -17,6 +17,10 @@ module Joint
     def read(*args)
       @io.read(*args)
     end
+    
+    def rewind
+      @io.rewind if @io.respond_to?(:rewind)
+    end
 
     alias path name
   end

--- a/test/joint/test_io.rb
+++ b/test/joint/test_io.rb
@@ -25,4 +25,15 @@ class IOTest < Test::Unit::TestCase
       Joint::IO.new(:content => 'Testing').read.should == 'Testing'
     end
   end
+  
+  context "#rewind" do
+    should "rewinds the io to position 0" do
+      io = Joint::IO.new(:content => 'Testing')
+      io.read.should == 'Testing'
+      io.read.should == ''
+      io.rewind
+      io.read.should == 'Testing'
+    end
+  end
+  
 end


### PR DESCRIPTION
Since Joint::IO's @io was updated to use a StringIO object for the content rather than just a String, we need access to the rewind method on @io. Discovered this when a bunch of my Rails tests started failing after upgrade from 0.5.x to 0.6.1.
