### PR TITLE
Don't define .name on Joint module

### DIFF
--- a/lib/joint.rb
+++ b/lib/joint.rb
@@ -11,27 +11,6 @@ module Joint
     include attachment_accessor_module
   end
 
-  def self.name(file)
-    if file.respond_to?(:original_filename)
-      file.original_filename
-    else
-      File.basename(file.path)
-    end
-  end
-
-  def self.size(file)
-    if file.respond_to?(:size)
-      file.size
-    else
-      File.size(file)
-    end
-  end
-
-  def self.type(file)
-    return file.type if file.is_a?(Joint::IO)
-    Wand.wave(file.path, :original_filename => Joint.name(file))
-  end
-
 private
   def self.blank?(str)
     str.nil? || str !~ /\S/
@@ -42,3 +21,4 @@ require 'joint/class_methods'
 require 'joint/instance_methods'
 require 'joint/attachment_proxy'
 require 'joint/io'
+require 'joint/file_helpers'

--- a/lib/joint/class_methods.rb
+++ b/lib/joint/class_methods.rb
@@ -37,9 +37,9 @@ module Joint
             assigned_attachments.delete(:#{name})
           else
             send("#{name}_id=", BSON::ObjectId.new) if send("#{name}_id").nil?
-            send("#{name}_name=", Joint.name(file))
-            send("#{name}_size=", Joint.size(file))
-            send("#{name}_type=", Joint.type(file))
+            send("#{name}_name=", Joint::FileHelpers.name(file))
+            send("#{name}_size=", Joint::FileHelpers.size(file))
+            send("#{name}_type=", Joint::FileHelpers.type(file))
             assigned_attachments[:#{name}] = file
             nil_attachments.delete(:#{name})
           end

--- a/lib/joint/file_helpers.rb
+++ b/lib/joint/file_helpers.rb
@@ -1,0 +1,24 @@
+module Joint
+  module FileHelpers
+    def self.name(file)
+      if file.respond_to?(:original_filename)
+        file.original_filename
+      else
+        File.basename(file.path)
+      end
+    end
+
+    def self.size(file)
+      if file.respond_to?(:size)
+        file.size
+      else
+        File.size(file)
+      end
+    end
+
+    def self.type(file)
+      return file.type if file.is_a?(Joint::IO)
+      Wand.wave(file.path, :original_filename => Joint::FileHelpers.name(file))
+    end
+  end
+end

--- a/test/joint/test_file_helpers.rb
+++ b/test/joint/test_file_helpers.rb
@@ -1,0 +1,52 @@
+require 'helper'
+
+class FileHelpersTest < Test::Unit::TestCase
+  include JointTestHelpers
+
+  def setup
+    super
+    @image  = open_file('mr_t.jpg')
+  end
+
+  def teardown
+    @image.close
+  end
+
+  context ".name" do
+    should "return original_filename" do
+      def @image.original_filename
+        'frank.jpg'
+      end
+      Joint::FileHelpers.name(@image).should == 'frank.jpg'
+    end
+
+    should "fall back to File.basename" do
+      Joint::FileHelpers.name(@image).should == 'mr_t.jpg'
+    end
+  end
+
+  context ".size" do
+    should "return size" do
+      def @image.size
+        25
+      end
+      Joint::FileHelpers.size(@image).should == 25
+    end
+
+    should "fall back to File.size" do
+      Joint::FileHelpers.size(@image).should == 13661
+    end
+  end
+
+  context ".type" do
+    should "return type if Joint::Io instance" do
+      file = Joint::IO.new(:type => 'image/jpeg')
+      Joint::FileHelpers.type(@image).should == 'image/jpeg'
+    end
+
+    should "fall back to Wand" do
+      Joint::FileHelpers.type(@image).should == 'image/jpeg'
+    end
+  end
+
+end

--- a/test/test_joint.rb
+++ b/test/test_joint.rb
@@ -16,43 +16,6 @@ class JointTest < Test::Unit::TestCase
     all_files.each { |file| file.close }
   end
 
-  context ".name" do
-    should "return original_filename" do
-      def @image.original_filename
-        'frank.jpg'
-      end
-      Joint.name(@image).should == 'frank.jpg'
-    end
-
-    should "fall back to File.basename" do
-      Joint.name(@image).should == 'mr_t.jpg'
-    end
-  end
-
-  context ".size" do
-    should "return size" do
-      def @image.size
-        25
-      end
-      Joint.size(@image).should == 25
-    end
-
-    should "fall back to File.size" do
-      Joint.size(@image).should == 13661
-    end
-  end
-
-  context ".type" do
-    should "return type if Joint::Io instance" do
-      file = Joint::IO.new(:type => 'image/jpeg')
-      Joint.type(@image).should == 'image/jpeg'
-    end
-
-    should "fall back to Wand" do
-      Joint.type(@image).should == 'image/jpeg'
-    end
-  end
-
   context "Using Joint plugin" do
     should "add each attachment to attachment_names" do
       Asset.attachment_names.should == Set.new([:image, :file])


### PR DESCRIPTION
Hey.. I hit a problem using Joint with @avdi's display_case gem.

It's accessing the name of classes like this: object.class.ancestors.map {|c| c.name}, which caused problems with the definition of self.name on the Joint active concern (as it takes a parameter).

All I've done here is move the utility methods like self.name and self.type and self.size to their own module.

It may well make sense to rename the .name method as well, as it's probably bad form.

Cheers, and thanks for all your awesome open source software!
